### PR TITLE
Correct tense and typo in benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Note: For a simple presentation, the questions in Domestic Robot and Open Game h
 
 - **imgs/**: 
 
-  - This directory contains the image which used in this page. However, It's not out benchmark images.
+  - This directory contains the images used on this page. However, they are not our benchmark images.
 
 
 - **results/**: 


### PR DESCRIPTION
Corrected the tense and the misspelling of "out" to "our"  and improved sentence structure for clarity. The updated sentence now reads: "This directory contains the images used on this page. However, they are not our benchmark images."